### PR TITLE
feat: integrate CoinGecko price analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ The main logic for chat will be found in the `Chat` component in `app/components
 - File Search Example: [http://localhost:3000/examples/file-search](http://localhost:3000/examples/file-search)
 - Full-featured Example: [http://localhost:3000/examples/all](http://localhost:3000/examples/all)
 
+### Utilities
+
+- `app/utils/crypto.ts` - helpers for fetching historical cryptocurrency prices from the CoinGecko API and comparing them with trade history
+
 ### Main Components
 
 - `app/components/chat.tsx` - handles chat rendering, [streaming](https://platform.openai.com/docs/assistants/overview?context=with-streaming), and [function call](https://platform.openai.com/docs/assistants/tools/function-calling/quickstart?context=streaming&lang=node.js) forwarding

--- a/app/examples/function-calling/page.tsx
+++ b/app/examples/function-calling/page.tsx
@@ -5,6 +5,10 @@ import styles from "../shared/page.module.css";
 import Chat from "../../components/chat";
 import WeatherWidget from "../../components/weather-widget";
 import { getWeather } from "../../utils/weather";
+import {
+  analyzeTradeTiming,
+  TradeAnalysis,
+} from "../../utils/crypto";
 import { RequiredActionFunctionToolCall } from "openai/resources/beta/threads/runs/runs";
 
 interface WeatherData {
@@ -15,14 +19,23 @@ interface WeatherData {
 
 const FunctionCalling = () => {
   const [weatherData, setWeatherData] = useState<WeatherData>({});
+  const [tradeAnalysis, setTradeAnalysis] = useState<TradeAnalysis[]>([]);
   const isEmpty = Object.keys(weatherData).length === 0;
 
   const functionCallHandler = async (call: RequiredActionFunctionToolCall) => {
-    if (call?.function?.name !== "get_weather") return;
-    const args = JSON.parse(call.function.arguments);
-    const data = getWeather(args.location);
-    setWeatherData(data);
-    return JSON.stringify(data);
+    if (call?.function?.name === "get_weather") {
+      const args = JSON.parse(call.function.arguments);
+      const data = getWeather(args.location);
+      setWeatherData(data);
+      return JSON.stringify(data);
+    }
+
+    if (call?.function?.name === "analyze_trades") {
+      const args = JSON.parse(call.function.arguments);
+      const data = await analyzeTradeTiming(args.coinId, args.trades);
+      setTradeAnalysis(data);
+      return JSON.stringify(data);
+    }
   };
 
   return (
@@ -35,6 +48,11 @@ const FunctionCalling = () => {
             conditions={weatherData.conditions || "Sunny"}
             isEmpty={isEmpty}
           />
+          <pre>
+            {tradeAnalysis.length
+              ? JSON.stringify(tradeAnalysis, null, 2)
+              : "No trade analysis"}
+          </pre>
         </div>
         <div className={styles.chatContainer}>
           <div className={styles.chat}>

--- a/app/utils/crypto.ts
+++ b/app/utils/crypto.ts
@@ -1,0 +1,63 @@
+export interface PricePoint {
+  time: number; // Unix timestamp in milliseconds
+  price: number;
+}
+
+export interface Trade {
+  timestamp: number; // Unix timestamp in seconds
+  amount: number;
+  price: number;
+}
+
+export interface TradeAnalysis {
+  trade: Trade;
+  marketPrice: number;
+  difference: number;
+}
+
+export async function fetchHistoricalPrices(
+  coinId: string,
+  from: number,
+  to: number,
+  vsCurrency = "usd"
+): Promise<PricePoint[]> {
+  const url = `https://api.coingecko.com/api/v3/coins/${coinId}/market_chart/range?vs_currency=${vsCurrency}&from=${from}&to=${to}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch price data: ${res.status} ${res.statusText}`);
+  }
+  const data = await res.json();
+  return (data.prices || []).map(([time, price]: [number, number]) => ({ time, price }));
+}
+
+function findClosestPrice(prices: PricePoint[], time: number): number {
+  let closest = prices[0].price;
+  let minDiff = Math.abs(prices[0].time - time * 1000); // prices time in ms
+  for (const p of prices) {
+    const diff = Math.abs(p.time - time * 1000);
+    if (diff < minDiff) {
+      minDiff = diff;
+      closest = p.price;
+    }
+  }
+  return closest;
+}
+
+export async function analyzeTradeTiming(
+  coinId: string,
+  trades: Trade[],
+  vsCurrency = "usd"
+): Promise<TradeAnalysis[]> {
+  if (trades.length === 0) return [];
+  const from = Math.min(...trades.map((t) => t.timestamp));
+  const to = Math.max(...trades.map((t) => t.timestamp));
+  const prices = await fetchHistoricalPrices(coinId, from, to, vsCurrency);
+  return trades.map((trade) => {
+    const marketPrice = findClosestPrice(prices, trade.timestamp);
+    return {
+      trade,
+      marketPrice,
+      difference: trade.price - marketPrice,
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- allow function-calling demo to analyze user trades via new `analyze_trades` handler
- add crypto utilities for fetching CoinGecko price history and comparing to trade data
- document crypto helpers in README

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: requires interactive setup)
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688e1d8e7ec0832b8ff72fc70a1cf60e