### PR TITLE
Add Aevo Copy Trader feed page

### DIFF
--- a/app/aevo-copy-trader/page.module.css
+++ b/app/aevo-copy-trader/page.module.css
@@ -1,0 +1,37 @@
+.main {
+  padding: 2rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.title {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.item {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #eaeaea;
+}
+
+.account {
+  font-weight: 600;
+}
+
+.action {
+  text-transform: uppercase;
+}
+
+.price,
+.size {
+  color: #555;
+}

--- a/app/aevo-copy-trader/page.tsx
+++ b/app/aevo-copy-trader/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import styles from "./page.module.css";
+
+interface Trade {
+  account?: string;
+  user?: string;
+  symbol?: string;
+  asset?: string;
+  side?: string;
+  direction?: string;
+  size?: number;
+  amount?: number;
+  price?: number;
+  execution_price?: number;
+  timestamp?: string;
+  executed_at?: string;
+}
+
+export default function AevoCopyTraderPage() {
+  const [trades, setTrades] = useState<Trade[]>([]);
+
+  useEffect(() => {
+    const fetchTrades = async () => {
+      try {
+        const res = await fetch("/api/aevo-copy-trader");
+        if (!res.ok) return;
+        const data = await res.json();
+        const list = data.trades || data.items || data.data || [];
+        setTrades(list);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
+    fetchTrades();
+    const id = setInterval(fetchTrades, 5000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <main className={styles.main}>
+      <h1 className={styles.title}>Aevo Copy Trader Feed</h1>
+      <ul className={styles.list}>
+        {trades.map((t, i) => (
+          <li key={i} className={styles.item}>
+            <span className={styles.account}>{t.account || t.user}</span>
+            <span className={styles.action}>
+              {t.side || t.direction} {t.symbol || t.asset}
+            </span>
+            <span className={styles.price}>@ {t.price || t.execution_price}</span>
+            <span className={styles.size}>size {t.size || t.amount}</span>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/api/aevo-copy-trader/route.ts
+++ b/app/api/aevo-copy-trader/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+
+const TRADES_FEED_URL = "https://api.aevo.xyz/v1/trades/recent";
+
+export async function GET() {
+  try {
+    const res = await fetch(TRADES_FEED_URL, {
+      headers: {
+        Accept: "application/json",
+        Origin: "https://degen.aevo.xyz",
+        Referer: "https://degen.aevo.xyz/",
+        "User-Agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+      },
+      cache: "no-store",
+    });
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: "Failed to fetch trades" },
+        { status: res.status }
+      );
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (err) {
+    return NextResponse.json(
+      { error: "Failed to fetch trades" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,10 +5,11 @@ import styles from "./page.module.css";
 
 const Home = () => {
   const categories = {
-    "Basic chat": "basic-chat",
-    "Function calling": "function-calling",
-    "File search": "file-search",
-    All: "all",
+    "Basic chat": "/examples/basic-chat",
+    "Function calling": "/examples/function-calling",
+    "File search": "/examples/file-search",
+    All: "/examples/all",
+    "Aevo Copy Trader": "/aevo-copy-trader",
   };
 
   return (
@@ -18,7 +19,7 @@ const Home = () => {
       </div>
       <div className={styles.container}>
         {Object.entries(categories).map(([name, url]) => (
-          <a key={name} className={styles.category} href={`/examples/${url}`}>
+          <a key={name} className={styles.category} href={url}>
             {name}
           </a>
         ))}


### PR DESCRIPTION
## Summary
- add Aevo Copy Trader card linking from the landing page
- create Aevo Copy Trader page that polls recent trades from Aevo API
- expose API route proxying Aevo trades feed

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689992ef9108832ba3b8e58be821f12e