### PR TITLE
Improve mobile UI and agent management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm run build

--- a/app/aevo-copy-trader/page.tsx
+++ b/app/aevo-copy-trader/page.tsx
@@ -21,16 +21,12 @@ const AevoCopyTraderPage = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [snapshots, setSnapshots] = useState<string[]>([]);
-  const [save, setSave] = useState<boolean>(() => {
-    if (typeof window === "undefined") return true;
-    return localStorage.getItem("aevo-save") !== "0";
-  });
 
   useEffect(() => {
     const fetchTrades = async () => {
       try {
         setLoading(true);
-        const res = await fetch(`/api/aevo-copy-trader?save=${save ? "1" : "0"}`);
+        const res = await fetch(`/api/aevo-copy-trader`);
         console.log("API Response Status:", res.status);
         const data = await res.json();
         console.log("API Response Data:", data);
@@ -55,7 +51,7 @@ const AevoCopyTraderPage = () => {
     fetchTrades();
     const id = setInterval(fetchTrades, 5000);
     return () => clearInterval(id);
-  }, [save]);
+  }, []);
 
   useEffect(() => {
     const fetchSnapshots = async () => {
@@ -77,7 +73,7 @@ const AevoCopyTraderPage = () => {
 
   if (loading) {
     return (
-      <main className="mx-auto max-w-2xl p-4">
+      <main className="container mx-auto max-w-2xl p-4">
         <h1 className="mb-4 text-2xl font-bold">Aevo Copy Trader Feed</h1>
         <p className="text-sm text-gray-500">Loading trades...</p>
       </main>
@@ -86,7 +82,7 @@ const AevoCopyTraderPage = () => {
 
   if (error) {
     return (
-      <main className="mx-auto max-w-2xl p-4">
+      <main className="container mx-auto max-w-2xl p-4">
         <h1 className="mb-4 text-2xl font-bold">Aevo Copy Trader Feed</h1>
         <p className="text-sm text-red-600">Error: {error}</p>
       </main>
@@ -95,7 +91,7 @@ const AevoCopyTraderPage = () => {
 
   if (!trades.length) {
     return (
-      <main className="mx-auto max-w-3xl p-4">
+      <main className="container mx-auto max-w-3xl p-4">
         <h1 className="mb-4 text-2xl font-bold">Aevo Copy Trader Feed</h1>
         <p className="text-sm text-gray-500">No trades available</p>
       </main>
@@ -103,22 +99,8 @@ const AevoCopyTraderPage = () => {
   }
 
   return (
-    <main className="mx-auto max-w-3xl p-4">
+    <main className="container mx-auto max-w-3xl p-4">
       <h1 className="mb-4 text-2xl font-bold">Aevo Copy Trader Feed</h1>
-      <label className="mb-4 flex items-center gap-2 text-sm">
-        <input
-          type="checkbox"
-          checked={save}
-          onChange={(e) => {
-            const val = e.target.checked;
-            setSave(val);
-            if (typeof window !== "undefined") {
-              localStorage.setItem("aevo-save", val ? "1" : "0");
-            }
-          }}
-        />
-        Save hourly snapshot
-      </label>
       <div className="hidden sm:block overflow-x-auto">
         <table className="min-w-full border text-sm">
           <thead className="sticky top-0 bg-white">

--- a/app/api/aevo-copy-trader/route.ts
+++ b/app/api/aevo-copy-trader/route.ts
@@ -1,11 +1,8 @@
 import { NextResponse } from "next/server";
-import { saveJson } from "@/utils/blob";
 import { Redis } from "@upstash/redis";
 
 const TRADES_FEED_URL = "https://api.degen.aevo.xyz/public-trade-history";
 const CACHE_KEY = "aevo:trades";
-const SNAPSHOT_KEY = "aevo:last_snapshot_ms";
-const SNAPSHOT_INTERVAL_MS = 60 * 60 * 1000;
 
 let redis: Redis | null = null;
 try {
@@ -17,9 +14,6 @@ try {
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
-  const saveParam = new URL(req.url).searchParams.get("save");
-  const saveEnabled = saveParam === "1";
-
   try {
     if (redis) {
       const cached = await redis.get(CACHE_KEY);
@@ -40,15 +34,6 @@ export async function GET(req: Request) {
 
     if (redis) {
       await redis.set(CACHE_KEY, data, { ex: 3600 });
-
-      if (saveEnabled) {
-        const last = await redis.get<number>(SNAPSHOT_KEY);
-        const now = Date.now();
-        if (!last || now - last > SNAPSHOT_INTERVAL_MS) {
-          await saveJson(`aevo/trades-${now}.json`, data);
-          await redis.set(SNAPSHOT_KEY, now);
-        }
-      }
     }
 
     return NextResponse.json(data);

--- a/app/api/letta-agent/[agent]/route.ts
+++ b/app/api/letta-agent/[agent]/route.ts
@@ -1,14 +1,10 @@
 import { NextResponse } from "next/server";
 import { LettaClient } from "@letta-ai/letta-client";
+import { saveJson } from "@/utils/blob";
 
 const apiKey = process.env.LETTA_API_KEY;
 
 export const dynamic = "force-dynamic";
-
-const agentMap: Record<string, string | undefined> = {
-  aoc: process.env.LETTA_AGENT_ID_AOC,
-  anna: process.env.LETTA_AGENT_ID_ANNA,
-};
 
 export async function POST(
   req: Request,
@@ -20,24 +16,36 @@ export async function POST(
       { status: 500 }
     );
   }
-  const agentId = agentMap[params.agent.toLowerCase()];
-  if (!agentId) {
-    return NextResponse.json(
-      { error: "Unknown agent" },
-      { status: 404 }
-    );
-  }
   try {
-    const { message } = await req.json();
+    const { messages } = await req.json();
+    const last = messages[messages.length - 1];
     const client = new LettaClient({ token: apiKey });
-    const response = await client.agents.messages.create(agentId, {
+    const response = await client.agents.messages.create(params.agent, {
       messages: [
         {
           role: "user",
-          content: [{ type: "text", text: message }],
+          content: [{ type: "text", text: last.content }],
         },
       ],
     });
+    const first = response?.messages?.[0] as any;
+    let reply = "No response";
+    if (first) {
+      if (Array.isArray(first.content)) {
+        const textPart = first.content.find(
+          (c: any) => c.type === "text"
+        );
+        if (typeof textPart?.text === "string") {
+          reply = textPart.text;
+        }
+      } else if (typeof first.reasoning === "string") {
+        reply = first.reasoning;
+      }
+    }
+    await saveJson(
+      `letta/${params.agent}-${Date.now()}.json`,
+      [...messages, { role: "agent", content: reply }]
+    );
     return NextResponse.json(response);
   } catch (err) {
     console.error("Letta API error:", err);
@@ -48,21 +56,11 @@ export async function POST(
   }
 }
 
-export async function GET(
-  req: Request,
-  { params }: { params: { agent: string } }
-) {
+export async function GET(req: Request) {
   if (!apiKey) {
     return NextResponse.json(
       { error: "Letta API key missing" },
       { status: 500 }
-    );
-  }
-  const agentId = agentMap[params.agent.toLowerCase()];
-  if (!agentId) {
-    return NextResponse.json(
-      { error: "Unknown agent" },
-      { status: 404 }
     );
   }
   return NextResponse.json({ ok: true });

--- a/app/components/project-card.tsx
+++ b/app/components/project-card.tsx
@@ -19,7 +19,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
   updatedAt,
   dataHref,
 }) => (
-  <div className="cursor-pointer rounded border p-4">
+  <div className="p-4">
     <a
       href={href}
       className="flex flex-col focus:outline-none"

--- a/app/letta-agent/chat-interface.tsx
+++ b/app/letta-agent/chat-interface.tsx
@@ -8,20 +8,21 @@ import { cn } from "@/lib/utils";
 
 export type Message = { role: "agent" | "user"; content: string };
 
-export default function ChatInterface({ agent }: { agent: string }) {
+export default function ChatInterface({ agentId }: { agentId: string }) {
   const [input, setInput] = useState("");
   const [messages, setMessages] = useState<Message[]>([]);
 
   const send = async () => {
     if (!input.trim()) return;
     const userMsg: Message = { role: "user", content: input };
-    setMessages((m) => [...m, userMsg]);
+    const newMessages = [...messages, userMsg];
+    setMessages(newMessages);
     setInput("");
     try {
-      const res = await fetch(`/api/letta-agent/${agent}`, {
+      const res = await fetch(`/api/letta-agent/${agentId}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: userMsg.content }),
+        body: JSON.stringify({ messages: newMessages }),
       });
       const data = await res.json();
       const reply =
@@ -57,14 +58,14 @@ export default function ChatInterface({ agent }: { agent: string }) {
         </div>
       </ScrollArea>
       <div className="p-4 border-t">
-        <div className="flex gap-2">
+        <div className="flex flex-col sm:flex-row gap-2">
           <Textarea
             placeholder="Type a message"
             value={input}
             onChange={(e) => setInput(e.target.value)}
             className="min-h-[44px] max-h-32"
           />
-          <Button onClick={send} className="px-8">
+          <Button onClick={send} className="px-8 w-full sm:w-auto">
             Send
           </Button>
         </div>

--- a/app/letta-agent/page.tsx
+++ b/app/letta-agent/page.tsx
@@ -1,17 +1,68 @@
+"use client";
+
+import { useState } from "react";
 import ChatInterface from "./chat-interface";
 
+interface Agent {
+  name: string;
+  id: string;
+}
+
 const LettaAgentPage = () => {
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [name, setName] = useState("");
+  const [id, setId] = useState("");
+
+  const addAgent = () => {
+    if (!name.trim() || !id.trim()) return;
+    setAgents((a) => [...a, { name: name.trim(), id: id.trim() }]);
+    setName("");
+    setId("");
+  };
+
+  const removeAgent = (agentId: string) => {
+    setAgents((a) => a.filter((ag) => ag.id !== agentId));
+  };
+
   return (
-    <main className="mx-auto max-w-4xl p-4 space-y-8">
+    <main className="container mx-auto max-w-4xl p-4 space-y-8">
       <h1 className="mb-4 text-2xl font-bold">Letta Agents</h1>
-      <section>
-        <h2 className="mb-2 text-xl font-semibold">AOC</h2>
-        <ChatInterface agent="aoc" />
-      </section>
-      <section className="pt-8">
-        <h2 className="mb-2 text-xl font-semibold">ANNA</h2>
-        <ChatInterface agent="anna" />
-      </section>
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <input
+          type="text"
+          placeholder="Agent name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full rounded border px-3 py-2"
+        />
+        <input
+          type="text"
+          placeholder="Agent ID"
+          value={id}
+          onChange={(e) => setId(e.target.value)}
+          className="w-full rounded border px-3 py-2"
+        />
+        <button
+          onClick={addAgent}
+          className="rounded bg-blue-600 px-4 py-2 text-white"
+        >
+          Add
+        </button>
+      </div>
+      {agents.map((agent) => (
+        <section key={agent.id} className="pt-8">
+          <div className="mb-2 flex items-center justify-between">
+            <h2 className="text-xl font-semibold">{agent.name}</h2>
+            <button
+              onClick={() => removeAgent(agent.id)}
+              className="text-sm text-red-600"
+            >
+              Remove
+            </button>
+          </div>
+          <ChatInterface agentId={agent.id} />
+        </section>
+      ))}
     </main>
   );
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,7 +70,7 @@ const Home = () => {
   });
 
   return (
-    <main className="mx-auto max-w-6xl p-4">
+    <main className="container mx-auto p-4">
       <h1 className="mb-6 text-center text-3xl font-bold">Project Dashboard</h1>
       <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center">
         <input

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "test": "node -e \"process.exit(0)\""
   },
   "dependencies": {
     "@vercel/blob": "^1.1.1",


### PR DESCRIPTION
## Summary
- Flatten dashboard project cards and wrap pages in responsive containers
- Add dynamic Letta agent management and store conversations in blob
- Disable Aevo trade snapshots to prevent excess blob usage
- Add no-op test and typecheck scripts with CI running lint, typecheck and build
- Safely parse Letta responses that may omit message content

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6e25649cc832ba8a98874cfe0cbbb