### PR TITLE
Add options chain explorer with provider choice and Gemini chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,10 @@ OPENAI_API_KEY="sk-123..."
 # (optional) Create an OpenAI Assistant at https://platform.openai.com/assistants.
 # IMPORTANT! Be sure to enable file search and code interpreter tools.
 OPENAI_ASSISTANT_ID="123..."
+
+# Google Gemini API key
+GEMINI_API_KEY="ai-123..."
+
+# Optional data provider keys
+TRADIER_TOKEN="abc123"
+ALPHA_VANTAGE_API_KEY="abc123"

--- a/app/api/options/chain/route.ts
+++ b/app/api/options/chain/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchChain } from '@/lib/options';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const symbol = searchParams.get('symbol');
+  const expiry = searchParams.get('expiry');
+  const provider = searchParams.get('provider') ?? 'yahoo';
+  if (!symbol || !expiry) {
+    return NextResponse.json({ error: 'symbol and expiry are required' }, { status: 400 });
+  }
+  try {
+    const contracts = await fetchChain(symbol, expiry, provider);
+    return NextResponse.json({ symbol, expiry, provider, contracts });
+  } catch (e) {
+    return NextResponse.json({ error: 'failed to fetch chain' }, { status: 500 });
+  }
+}

--- a/app/api/options/chat/route.ts
+++ b/app/api/options/chat/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchChain } from '@/lib/options';
+
+async function callGemini(question: string, context: string): Promise<string> {
+  const key = process.env.GEMINI_API_KEY;
+  if (!key) throw new Error('GEMINI_API_KEY not set');
+  const body = {
+    contents: [
+      {
+        role: 'user',
+        parts: [{ text: `${context}\n\nQuestion: ${question}` }],
+      },
+    ],
+  };
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${key}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }
+  );
+  if (!res.ok) throw new Error('Gemini API error');
+  const json = await res.json();
+  const text =
+    json?.candidates?.[0]?.content?.parts?.[0]?.text?.toString().trim() || '';
+  return text;
+}
+
+export async function POST(req: NextRequest) {
+  const { question, symbol, expiry, provider } = await req.json();
+  if (!question || !symbol || !expiry) {
+    return NextResponse.json({ error: 'missing params' }, { status: 400 });
+  }
+  try {
+    const chain = await fetchChain(symbol, expiry, provider ?? 'yahoo');
+    const context = chain
+      .slice(0, 20)
+      .map(
+        (c) =>
+          `${c.type} ${c.strike} bid ${c.bid} ask ${c.ask} oi ${c.openInterest} iv ${c.impliedVolatility}`
+      )
+      .join('\n');
+    const answer = await callGemini(
+      question,
+      `Options data for ${symbol} ${expiry}:\n${context}`
+    );
+    return NextResponse.json({ answer });
+  } catch (e) {
+    return NextResponse.json({ error: 'failed to get answer' }, { status: 500 });
+  }
+}

--- a/app/api/options/expiries/route.ts
+++ b/app/api/options/expiries/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchExpiries } from '@/lib/options';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const symbol = searchParams.get('symbol');
+  const provider = searchParams.get('provider') ?? 'yahoo';
+  if (!symbol) {
+    return NextResponse.json({ error: 'symbol is required' }, { status: 400 });
+  }
+  try {
+    const expiries = await fetchExpiries(symbol, provider);
+    return NextResponse.json({ symbol, provider, expiries });
+  } catch (e) {
+    return NextResponse.json({ error: 'failed to fetch expiries' }, { status: 500 });
+  }
+}

--- a/app/options/page.tsx
+++ b/app/options/page.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+
+type Contract = {
+  type: string;
+  strike: number;
+  bid: number | null;
+  ask: number | null;
+  volume: number | null;
+  openInterest: number | null;
+  impliedVolatility: number | null;
+};
+
+const providers = [
+  { value: 'yahoo', label: 'Yahoo' },
+  { value: 'tradier', label: 'Tradier' },
+  { value: 'alphavantage', label: 'Alpha Vantage' },
+];
+
+export default function OptionsPage() {
+  const [symbol, setSymbol] = useState('AAPL');
+  const [provider, setProvider] = useState('yahoo');
+  const [expiries, setExpiries] = useState<string[]>([]);
+  const [expiry, setExpiry] = useState('');
+  const [contracts, setContracts] = useState<Contract[]>([]);
+  const [question, setQuestion] = useState('');
+  const [answer, setAnswer] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      setExpiry('');
+      setContracts([]);
+      try {
+        const res = await fetch(`/api/options/expiries?symbol=${symbol}&provider=${provider}`);
+        const json = await res.json();
+        setExpiries(json.expiries || []);
+        if (json.expiries && json.expiries.length) {
+          setExpiry(json.expiries[0]);
+        }
+      } catch {
+        setExpiries([]);
+      }
+    };
+    load();
+  }, [symbol, provider]);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!expiry) return;
+      try {
+        const res = await fetch(`/api/options/chain?symbol=${symbol}&expiry=${expiry}&provider=${provider}`);
+        const json = await res.json();
+        setContracts(json.contracts || []);
+      } catch {
+        setContracts([]);
+      }
+    };
+    load();
+  }, [expiry, provider, symbol]);
+
+  const ask = async () => {
+    setLoading(true);
+    setAnswer('');
+    try {
+      const res = await fetch('/api/options/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question, symbol, expiry, provider }),
+      });
+      const json = await res.json();
+      setAnswer(json.answer || json.error || '');
+    } catch {
+      setAnswer('Error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto max-w-4xl p-4">
+      <h1 className="mb-4 text-2xl font-bold">Options Chain Explorer</h1>
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center">
+        <input
+          value={symbol}
+          onChange={(e) => setSymbol(e.target.value.toUpperCase())}
+          className="border px-2 py-1"
+          placeholder="Ticker"
+        />
+        <select
+          value={provider}
+          onChange={(e) => setProvider(e.target.value)}
+          className="border px-2 py-1"
+        >
+          {providers.map((p) => (
+            <option key={p.value} value={p.value}>
+              {p.label}
+            </option>
+          ))}
+        </select>
+        <select
+          value={expiry}
+          onChange={(e) => setExpiry(e.target.value)}
+          className="border px-2 py-1"
+        >
+          {expiries.map((e) => (
+            <option key={e} value={e}>
+              {e}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full border text-sm">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="border px-2">Type</th>
+              <th className="border px-2">Strike</th>
+              <th className="border px-2">Bid</th>
+              <th className="border px-2">Ask</th>
+              <th className="border px-2">Vol</th>
+              <th className="border px-2">OI</th>
+              <th className="border px-2">IV%</th>
+            </tr>
+          </thead>
+          <tbody>
+            {contracts.map((c, idx) => (
+              <tr key={idx}>
+                <td className="border px-2 text-center">{c.type}</td>
+                <td className="border px-2 text-right">{c.strike}</td>
+                <td className="border px-2 text-right">{c.bid ?? '-'}</td>
+                <td className="border px-2 text-right">{c.ask ?? '-'}</td>
+                <td className="border px-2 text-right">{c.volume ?? '-'}</td>
+                <td className="border px-2 text-right">{c.openInterest ?? '-'}</td>
+                <td className="border px-2 text-right">{c.impliedVolatility ?? '-'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="mt-6">
+        <h2 className="mb-2 font-semibold">Ask the AI</h2>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <input
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+            className="flex-grow border px-2 py-1"
+            placeholder="Question about this chain"
+          />
+          <button
+            onClick={ask}
+            disabled={loading}
+            className="rounded bg-blue-600 px-3 py-1 text-white disabled:opacity-50"
+          >
+            Ask
+          </button>
+        </div>
+        {answer && <p className="mt-2 whitespace-pre-wrap text-sm">{answer}</p>}
+      </div>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,6 +55,13 @@ const projects: Project[] = [
     status: "live",
     updatedAt: "2024-07-22",
   },
+  {
+    title: "Options Chain Explorer",
+    href: "/options",
+    tags: ["finance", "options"],
+    status: "live",
+    updatedAt: "2024-07-22",
+  },
 ];
 
 const allTags = ["All", ...Array.from(new Set(projects.flatMap((p) => p.tags)))];

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -1,0 +1,154 @@
+const AV_KEY = process.env.ALPHA_VANTAGE_API_KEY;
+const TRADIER_TOKEN = process.env.TRADIER_TOKEN;
+
+export interface OptionContract {
+  type: 'call' | 'put';
+  strike: number;
+  bid: number | null;
+  ask: number | null;
+  volume: number | null;
+  openInterest: number | null;
+  impliedVolatility: number | null;
+}
+
+function toYMD(date: Date): string {
+  const yr = date.getUTCFullYear();
+  const mo = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const da = String(date.getUTCDate()).padStart(2, '0');
+  return `${yr}-${mo}-${da}`;
+}
+
+async function fetchYahoo(symbol: string, expiry?: string) {
+  const base = `https://query1.finance.yahoo.com/v7/finance/options/${encodeURIComponent(symbol)}`;
+  const url = expiry ? `${base}?date=${Math.floor(new Date(expiry + 'T00:00:00Z').getTime() / 1000)}` : base;
+  const res = await fetch(url, { cache: 'no-store' });
+  if (!res.ok) throw new Error('Yahoo request failed');
+  const json = await res.json();
+  const result = json?.optionChain?.result?.[0];
+  if (!result) return { expiries: [], chain: [] };
+  const expiries: string[] = (result.expirationDates || []).map((ts: number) => toYMD(new Date(ts * 1000)));
+  const options = result.options?.[0];
+  const chain: OptionContract[] = [];
+  if (options) {
+    const calls = options.calls || [];
+    const puts = options.puts || [];
+    for (const c of calls) {
+      chain.push({
+        type: 'call',
+        strike: c.strike,
+        bid: c.bid ?? null,
+        ask: c.ask ?? null,
+        volume: c.volume ?? null,
+        openInterest: c.openInterest ?? null,
+        impliedVolatility: c.impliedVolatility != null ? Number((c.impliedVolatility * 100).toFixed(2)) : null,
+      });
+    }
+    for (const p of puts) {
+      chain.push({
+        type: 'put',
+        strike: p.strike,
+        bid: p.bid ?? null,
+        ask: p.ask ?? null,
+        volume: p.volume ?? null,
+        openInterest: p.openInterest ?? null,
+        impliedVolatility: p.impliedVolatility != null ? Number((p.impliedVolatility * 100).toFixed(2)) : null,
+      });
+    }
+  }
+  return { expiries, chain };
+}
+
+async function fetchTradier(symbol: string, expiry?: string) {
+  if (!TRADIER_TOKEN) throw new Error('TRADIER_TOKEN not set');
+  if (!expiry) {
+    const url = `https://api.tradier.com/v1/markets/options/expirations?symbol=${encodeURIComponent(symbol)}`;
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${TRADIER_TOKEN}`, Accept: 'application/json' }, cache: 'no-store' });
+    if (!res.ok) throw new Error('Tradier expiries failed');
+    const json = await res.json();
+    const expiries: string[] = json?.expirations?.date || [];
+    return { expiries, chain: [] };
+  }
+  const url = `https://api.tradier.com/v1/markets/options/chains?symbol=${encodeURIComponent(symbol)}&expiration=${expiry}&greeks=true`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${TRADIER_TOKEN}`, Accept: 'application/json' }, cache: 'no-store' });
+  if (!res.ok) throw new Error('Tradier chain failed');
+  const json = await res.json();
+  const options = json?.options?.option || [];
+  const chain: OptionContract[] = options.map((o: any) => ({
+    type: o.option_type,
+    strike: o.strike,
+    bid: o.bid ?? null,
+    ask: o.ask ?? null,
+    volume: o.volume ?? null,
+    openInterest: o.open_interest ?? null,
+    impliedVolatility: o.greeks?.mid_iv != null ? Number((o.greeks.mid_iv * 100).toFixed(2)) : null,
+  }));
+  return { expiries: [], chain };
+}
+
+async function fetchAlpha(symbol: string, expiry?: string) {
+  if (!AV_KEY) throw new Error('ALPHA_VANTAGE_API_KEY not set');
+  const url = `https://www.alphavantage.co/query?function=OPTIONS_CHAIN&symbol=${encodeURIComponent(symbol)}&apikey=${AV_KEY}`;
+  const res = await fetch(url, { cache: 'no-store' });
+  if (!res.ok) throw new Error('Alpha Vantage request failed');
+  const json = await res.json();
+  const data = json?.data || {};
+  const expiries = Object.keys(data);
+  if (!expiry) {
+    return { expiries, chain: [] };
+  }
+  const expData = data[expiry];
+  const chain: OptionContract[] = [];
+  if (expData) {
+    const calls = expData.call || [];
+    const puts = expData.put || [];
+    for (const c of calls) {
+      chain.push({
+        type: 'call',
+        strike: Number(c.strikePrice),
+        bid: c.bid ?? null,
+        ask: c.ask ?? null,
+        volume: c.volume ?? null,
+        openInterest: c.openInterest ?? null,
+        impliedVolatility: c.impliedVolatility != null ? Number(c.impliedVolatility) : null,
+      });
+    }
+    for (const p of puts) {
+      chain.push({
+        type: 'put',
+        strike: Number(p.strikePrice),
+        bid: p.bid ?? null,
+        ask: p.ask ?? null,
+        volume: p.volume ?? null,
+        openInterest: p.openInterest ?? null,
+        impliedVolatility: p.impliedVolatility != null ? Number(p.impliedVolatility) : null,
+      });
+    }
+  }
+  return { expiries, chain };
+}
+
+export async function fetchExpiries(symbol: string, provider: string): Promise<string[]> {
+  switch (provider) {
+    case 'tradier':
+      return (await fetchTradier(symbol)).expiries;
+    case 'alpha':
+    case 'alphavantage':
+      return (await fetchAlpha(symbol)).expiries;
+    case 'yahoo':
+    default:
+      return (await fetchYahoo(symbol)).expiries;
+  }
+}
+
+export async function fetchChain(symbol: string, expiry: string, provider: string): Promise<OptionContract[]> {
+  switch (provider) {
+    case 'tradier':
+      return (await fetchTradier(symbol, expiry)).chain;
+    case 'alpha':
+    case 'alphavantage':
+      return (await fetchAlpha(symbol, expiry)).chain;
+    case 'yahoo':
+    default:
+      return (await fetchYahoo(symbol, expiry)).chain;
+  }
+}


### PR DESCRIPTION
## Summary
- add Options Chain Explorer project card and page
- support Yahoo, Tradier, and Alpha Vantage providers with front-end selector
- enable Gemini-based chat about option chains and example env variables

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adb965d438832ba601df796a1b6014