### PR TITLE
feat: add dynamic letta chat page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,8 @@ OPENAI_API_KEY="sk-123..."
 # (optional) Create an OpenAI Assistant at https://platform.openai.com/assistants.
 # IMPORTANT! Be sure to enable file search and code interpreter tools.
 OPENAI_ASSISTANT_ID="123..."
+
+# Letta API key and optional agent IDs for demo pages
+LETTA_KEY="letta-123..."
+LETTA_AGENT_ID_AOC="agent-..."
+LETTA_AGENT_ID_ANNA="agent-..."

--- a/app/api/letta-agent/[agent]/route.ts
+++ b/app/api/letta-agent/[agent]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { LettaClient } from "@letta-ai/letta-client";
 
-const apiKey = process.env.LETTA_API_KEY;
+const apiKey = process.env.LETTA_KEY;
 
 export const dynamic = "force-dynamic";
 

--- a/app/api/letta/route.ts
+++ b/app/api/letta/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { LettaClient } from "@letta-ai/letta-client";
+
+const apiKey = process.env.LETTA_KEY;
+
+export async function POST(req: Request) {
+  if (!apiKey) {
+    return NextResponse.json({ error: "Letta API key missing" }, { status: 500 });
+  }
+  try {
+    const { agentId, message } = await req.json();
+    if (!agentId) {
+      return NextResponse.json({ error: "Missing agent ID" }, { status: 400 });
+    }
+    const client = new LettaClient({ token: apiKey });
+    const response = await client.agents.messages.create(agentId, {
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: message }],
+        },
+      ],
+    });
+    const reply = response?.messages?.[0]?.content?.[0]?.text ?? "";
+    return NextResponse.json({ reply, raw: response });
+  } catch (err) {
+    console.error("Letta API error:", err);
+    return NextResponse.json(
+      { error: "Failed to contact Letta" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(req: Request) {
+  if (!apiKey) {
+    return NextResponse.json({ error: "Letta API key missing" }, { status: 500 });
+  }
+  try {
+    const { agentId } = await req.json();
+    if (!agentId) {
+      return NextResponse.json({ error: "Missing agent ID" }, { status: 400 });
+    }
+    const client = new LettaClient({ token: apiKey });
+    await client.agents.messages.reset(agentId);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("Letta API reset error:", err);
+    return NextResponse.json(
+      { error: "Failed to reset agent" },
+      { status: 500 }
+    );
+  }
+}
+

--- a/app/letta/page.tsx
+++ b/app/letta/page.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+
+export type Message = { role: "agent" | "user"; content: string };
+
+export default function LettaPage() {
+  const [agentId, setAgentId] = useState("");
+  const [input, setInput] = useState("");
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [rawOutput, setRawOutput] = useState<string>("");
+
+  const send = async () => {
+    if (!input.trim() || !agentId.trim()) return;
+    const userMsg: Message = { role: "user", content: input };
+    setMessages((m) => [...m, userMsg]);
+    setInput("");
+    try {
+      const res = await fetch("/api/letta", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId, message: userMsg.content }),
+      });
+      const data = await res.json();
+      const reply = data?.reply || data?.error || "No response";
+      setMessages((m) => [...m, { role: "agent", content: reply }]);
+      setRawOutput(JSON.stringify(data.raw, null, 2));
+    } catch (err) {
+      setMessages((m) => [
+        ...m,
+        { role: "agent", content: "Error contacting agent" },
+      ]);
+    }
+  };
+
+  const newThread = async () => {
+    if (agentId.trim()) {
+      await fetch("/api/letta", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agentId }),
+      });
+    }
+    setMessages([]);
+    setRawOutput("");
+  };
+
+  return (
+    <main className="mx-auto max-w-5xl p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Letta Chat</h1>
+      <div className="flex flex-col gap-2 md:flex-row md:items-center">
+        <input
+          type="text"
+          placeholder="Agent ID"
+          value={agentId}
+          onChange={(e) => setAgentId(e.target.value)}
+          className="w-full rounded border px-3 py-2"
+        />
+        <Button variant="secondary" onClick={newThread}>
+          New Thread
+        </Button>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="flex flex-col h-[60vh] border rounded">
+          <ScrollArea className="flex-1 p-4">
+            <div className="space-y-4">
+              {messages.map((m, i) => (
+                <div
+                  key={i}
+                  className={cn(
+                    "flex gap-2 max-w-[80%]",
+                    m.role === "user" && "ml-auto"
+                  )}
+                >
+                  {m.role === "agent" && (
+                    <div className="h-8 w-8 rounded-full bg-primary flex-shrink-0" />
+                  )}
+                  <div className="p-3 bg-muted/50 rounded-lg">
+                    <p className="text-sm whitespace-pre-wrap">{m.content}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </ScrollArea>
+          <div className="p-4 border-t">
+            <div className="flex gap-2">
+              <Textarea
+                placeholder="Type a message"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                className="min-h-[44px] max-h-32"
+              />
+              <Button onClick={send} className="px-8">
+                Send
+              </Button>
+            </div>
+          </div>
+        </div>
+        <div className="h-[60vh] border rounded p-4 overflow-auto">
+          <h2 className="font-semibold mb-2">Agent Canvas</h2>
+          <pre className="text-xs whitespace-pre-wrap">{rawOutput}</pre>
+        </div>
+      </div>
+    </main>
+  );
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,6 +55,13 @@ const projects: Project[] = [
     status: "live",
     updatedAt: "2024-07-22",
   },
+  {
+    title: "Letta Chat",
+    href: "/letta",
+    tags: ["chat", "agent"],
+    status: "live",
+    updatedAt: "2024-07-22",
+  },
 ];
 
 const allTags = ["All", ...Array.from(new Set(projects.flatMap((p) => p.tags)))];


### PR DESCRIPTION
## Summary
- add `/letta` chat page with agent id input and canvas panel
- proxy Letta API via new `/api/letta` endpoint and support resets
- switch Letta env var to `LETTA_KEY` and link page from dashboard

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2f6492f38832ba386552996ad3965