### PR TITLE
fix: align chat input and centralize API keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,9 @@ OPENAI_API_KEY="sk-123..."
 # (optional) Create an OpenAI Assistant at https://platform.openai.com/assistants.
 # IMPORTANT! Be sure to enable file search and code interpreter tools.
 OPENAI_ASSISTANT_ID="123..."
+
+# (optional) Gemini API key for Google Generative AI
+GEMINI_KEY="abc..."
+
+# (optional) Letta API key for Letta agents
+LETTA_API_KEY="xyz..."

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ export OPENAI_API_KEY="sk_..."
 ```shell
 npm install
 ```
+Install all dependencies so packages like [`jszip`](https://www.npmjs.com/package/jszip) are available for features such as the Zip to Text Extractor.
 
 ### 4. Run
 

--- a/app/api/letta-agent/[agent]/route.ts
+++ b/app/api/letta-agent/[agent]/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { LettaClient } from "@letta-ai/letta-client";
+import { LETTA_API_KEY } from "@/lib/env";
 
-const apiKey = process.env.LETTA_API_KEY;
+const apiKey = LETTA_API_KEY;
 
 export const dynamic = "force-dynamic";
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -20,10 +20,20 @@ html,
 body {
   max-width: 100vw;
   overflow-x: hidden;
+  height: 100%;
 }
 
 body {
   color: rgb(var(--foreground-rgb));
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 }
 
 a {

--- a/app/openai.ts
+++ b/app/openai.ts
@@ -1,5 +1,6 @@
 import OpenAI from "openai";
+import { OPENAI_API_KEY } from "@/lib/env";
 
-export const openai = process.env.OPENAI_API_KEY
-  ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+export const openai = OPENAI_API_KEY
+  ? new OpenAI({ apiKey: OPENAI_API_KEY })
   : null;

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,3 @@
+export const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+export const GEMINI_KEY = process.env.GEMINI_KEY;
+export const LETTA_API_KEY = process.env.LETTA_API_KEY;


### PR DESCRIPTION
## Summary
- Ensure pages fill the viewport so chat input stays pinned to the bottom
- Centralize environment variable access for OpenAI, Gemini, and Letta APIs
- Document Gemini and Letta keys in `.env.example`
- Mention installing all dependencies (including `jszip`) in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6126c23c4832b8ad94712831c78ad